### PR TITLE
Remove pytest.ini that causes pytest to issue warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,8 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+# type: ignore
+
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-ignore =
-    docs/conf.py


### PR DESCRIPTION
Also add `# type: ignore` to `docs/conf.py` so that it doesn't cause failures from mypy analysis.

Fixes #58 