### PR TITLE
Add 'add_source' to Biblio

### DIFF
--- a/r2t2/core.py
+++ b/r2t2/core.py
@@ -1,7 +1,8 @@
 import inspect
 import wrapt
-from typing import NamedTuple, List, Optional, Callable
+from typing import NamedTuple, List, Optional, Callable, Dict, Union
 from functools import reduce
+from pathlib import Path
 
 
 class FunctionReference(NamedTuple):
@@ -14,6 +15,10 @@ class FunctionReference(NamedTuple):
 
 class Biblio(dict):
     track_references: bool = False
+
+    def __init__(self):
+        super().__init__()
+        self._sources: Dict[str, Path] = {}
 
     def __str__(self):
         def add_record(out, record):
@@ -41,6 +46,28 @@ class Biblio(dict):
     def tracking(self, enabled=True):
         """Enable the tracking of references."""
         self.track_references = enabled
+
+    def add_source(self, source: Union[str, Path]) -> None:
+        """Adds a bibliography source to the list of known sources.
+
+        Args:
+            source (str, Path): Path to the references source file. This must be a
+                bibtex file.
+
+        Raises:
+            ValueError if the file is not bibtex.
+            RuntimeError if the file does not exist.
+
+        Returns:
+            None
+        """
+        package = inspect.getmodule(inspect.stack()[1][0]).__name__.split(".")[0]
+        src = Path(source)
+        if src.suffix != ".bib":
+            raise ValueError("References sources must be in bibtex format '.bib'")
+        if not src.is_file():
+            raise RuntimeError(f"References source file '{src}' does not exist!")
+        self._sources[package] = src
 
 
 BIBLIOGRAPHY: Biblio = Biblio()

--- a/r2t2/core.py
+++ b/r2t2/core.py
@@ -73,8 +73,9 @@ class Biblio(dict):
         if not src.is_file():
             raise RuntimeError(f"References source file '{src}' does not exist!")
         if package in self._sources:
-            raise RuntimeError(f"A reference source for this package has already been "
-                               f"added")
+            raise RuntimeError(
+                f"A reference source for this package has already been " f"added"
+            )
         self._sources[package] = src
 
 
@@ -120,8 +121,9 @@ def add_reference(
             return wrapped(*args, **kwargs)
 
         if identifier not in BIBLIOGRAPHY:
-            BIBLIOGRAPHY[identifier] = FunctionReference(wrapped.__name__, line, source,
-                                                         [], [])
+            BIBLIOGRAPHY[identifier] = FunctionReference(
+                wrapped.__name__, line, source, [], []
+            )
 
         BIBLIOGRAPHY[identifier].short_purpose.append(short_purpose)
         BIBLIOGRAPHY[identifier].references.append(ref)

--- a/r2t2/core.py
+++ b/r2t2/core.py
@@ -74,7 +74,7 @@ class Biblio(dict):
             raise RuntimeError(f"References source file '{src}' does not exist!")
         if package in self._sources:
             raise RuntimeError(
-                f"A reference source for this package has already been " f"added"
+                "A reference source for this package has already been added"
             )
         self._sources[package] = src
 

--- a/r2t2/core.py
+++ b/r2t2/core.py
@@ -34,6 +34,10 @@ class Biblio(dict):
 
         return reduce(add_record, self.values(), "")
 
+    def clear(self) -> None:
+        super().clear()
+        self._sources.clear()
+
     @property
     def references(self):
         """Return a list of unique references."""
@@ -57,6 +61,7 @@ class Biblio(dict):
         Raises:
             ValueError if the file is not bibtex.
             RuntimeError if the file does not exist.
+            RuntimeError if the package already has a reference.
 
         Returns:
             None
@@ -67,6 +72,9 @@ class Biblio(dict):
             raise ValueError("References sources must be in bibtex format '.bib'")
         if not src.is_file():
             raise RuntimeError(f"References source file '{src}' does not exist!")
+        if package in self._sources:
+            raise RuntimeError(f"A reference source for this package has already been "
+                               f"added")
         self._sources[package] = src
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,5 @@
 from r2t2.core import add_reference
+from pytest import raises
 
 
 class TestAddReference:
@@ -82,3 +83,23 @@ class TestAddReference:
     def test_add_reference_from_doi(self, bib_with_tracking, decorated_with_doi):
         decorated_with_doi()
         assert "https://doi.org/" in bib_with_tracking.references[-1]
+
+
+class TestAddSource:
+
+    def test_add_source_exception_if_not_bibtex(self, bibliography, tmp_path):
+        source = tmp_path / "my_source"
+        with raises(ValueError):
+            bibliography.add_source(source)
+
+    def test_add_source_exception_if_not_exist(self, bibliography, tmp_path):
+        source = tmp_path / "my_source.bib"
+        with raises(RuntimeError):
+            bibliography.add_source(source)
+
+    def test_add_source(self, bibliography, tmp_path):
+        source = tmp_path / "my_source.bib"
+        source.open("w").close()
+        bibliography.add_source(source)
+        assert "tests" in bibliography._sources
+        assert bibliography._sources["tests"] == source

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -97,6 +97,13 @@ class TestAddSource:
         with raises(RuntimeError):
             bibliography.add_source(source)
 
+    def test_add_source_exception_source_exists(self, bibliography, tmp_path):
+        source = tmp_path / "my_source.bib"
+        source.open("w").close()
+        bibliography._sources["tests"] = "placeholder"
+        with raises(RuntimeError):
+            bibliography.add_source(source)
+
     def test_add_source(self, bibliography, tmp_path):
         source = tmp_path / "my_source.bib"
         source.open("w").close()


### PR DESCRIPTION
Implements method to add a reference source to bibliography. This should be called somewhere within a package and there can be only one source per package.

Related to #51 