### PR TITLE
cli sub commands

### DIFF
--- a/docs/examples/minimal.py
+++ b/docs/examples/minimal.py
@@ -7,3 +7,7 @@ from r2t2 import add_reference
                "http://doi.org/10.5281/zenodo.1185316")
 def my_great_function():
     pass
+
+
+if __name__ == "__main__":
+    my_great_function()

--- a/r2t2/__main__.py
+++ b/r2t2/__main__.py
@@ -40,7 +40,11 @@ def add_common_arguments(parser: argparse.ArgumentParser):
         choices=sorted(REGISTERED_WRITERS.keys()),
         help="Format of the output. Default: Terminal."
     )
-
+    parser.add_argument(
+        "--encoding",
+        default="utf-8",
+        help="The encoding to use when parsing files.",
+    )
     parser.add_argument(
         "-o",
         "--output",
@@ -75,7 +79,7 @@ class RunSubCommand(SubCommand):
         )
 
     def run(self, args: argparse.Namespace):
-        runtime_tracker(args.target, args.args)
+        runtime_tracker(args.target, args.args, encoding=args.encoding)
 
 
 class StaticSubCommand(SubCommand):
@@ -93,11 +97,6 @@ class StaticSubCommand(SubCommand):
             "--notebook",
             action="store_true",
             help="Parse markdown cells from Jupyter notebooks.",
-        )
-        parser.add_argument(
-            "--encoding",
-            default="utf-8",
-            help="The encoding to use when parsing files.",
         )
         parser.add_argument(
             "target",

--- a/r2t2/runtime_tracker.py
+++ b/r2t2/runtime_tracker.py
@@ -1,6 +1,11 @@
-from .core import BIBLIOGRAPHY
+import logging
 import sys
 import os
+
+from .core import BIBLIOGRAPHY
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def runtime_tracker(script, args):
@@ -10,6 +15,7 @@ def runtime_tracker(script, args):
     sys.path[0] = os.path.dirname(script)
 
     try:
+        LOGGER.debug("loading script: %s (args: %s)", script, args)
         with open(script) as fp:
             code = compile(fp.read(), script, "exec")
 

--- a/r2t2/runtime_tracker.py
+++ b/r2t2/runtime_tracker.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import os
+from typing import List
 
 from .core import BIBLIOGRAPHY
 
@@ -8,15 +9,18 @@ from .core import BIBLIOGRAPHY
 LOGGER = logging.getLogger(__name__)
 
 
-def runtime_tracker(script, args):
+def runtime_tracker(script: str, args: List[str], encoding: str):
     BIBLIOGRAPHY.tracking()
 
     sys.argv = [script, *args]
     sys.path[0] = os.path.dirname(script)
 
     try:
-        LOGGER.debug("loading script: %s (args: %s)", script, args)
-        with open(script) as fp:
+        LOGGER.debug(
+            "loading script: %s (args: %s, encoding: %s)",
+            script, args, encoding
+        )
+        with open(script, encoding=encoding) as fp:
             code = compile(fp.read(), script, "exec")
 
         # try to emulate __main__ namespace as much as possible

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from py._path.local import LocalPath
 def bibliography():
     from r2t2 import BIBLIOGRAPHY
 
+    BIBLIOGRAPHY.tracking(False)
     yield BIBLIOGRAPHY
     BIBLIOGRAPHY.clear()
 

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -13,6 +13,7 @@ INVALID_FORMAT = 'other'
 class TestParseArgs:
     def test_should_not_fail_on_valid_format(self):
         args = parse_args([
+            'run',
             '--format=%s' % VALID_FORMAT,
             'docs/examples'
         ])
@@ -21,6 +22,7 @@ class TestParseArgs:
     def test_should_fail_on_invalid_format(self):
         with pytest.raises(SystemExit):
             parse_args([
+                'run',
                 '--format=%s' % INVALID_FORMAT,
                 'docs/examples'
             ])
@@ -32,7 +34,7 @@ class TestMain:
         self
     ):
         main([
-            '--static',
+            'static',
             '--docstring',
             'docs/examples'
         ])
@@ -41,18 +43,19 @@ class TestMain:
         self
     ):
         main([
-            '--static',
+            'static',
             'docs/examples'
         ])
 
     def test_should_not_fail_on_runtime_analysis_of_examples(self):
         main([
-            'docs/examples'
+            'run',
+            'docs/examples/minimal.py'
         ])
 
     def test_should_not_fail_on_notebook(self):
         main([
-            '--static',
+            'static',
             '--notebook',
             'tests/fixtures/notebook_doi.ipynb'
         ])
@@ -60,7 +63,7 @@ class TestMain:
     def test_should_fail_on_non_notebook(self):
         with pytest.raises(Exception):
             main([
-                '--static',
+                'static',
                 '--notebook',
                 'docs/examples/docstring_doi.py'
             ])


### PR DESCRIPTION
part of #54

This changes the CLI to use sub commands rather than a `--static` flag. i.e.

```console
$python -m r2t2 run <script> [--] [... args]

# or
$python -m r2t2 static <directory or script>
```

I also added a `--debug` flag that would enable debug logging (if any).

This doesn't currently support multiple scripts, but it is making the usage a bit more clear by using sub commands.
e.g. parameters not used by a particular mode won't be accepted.

I'd say supporting multiple scripts should be a separate PR.

TODO: The documentation will need to get updated